### PR TITLE
Fix embedding parameter serialization in similarity search query

### DIFF
--- a/backend/src/chat.service.ts
+++ b/backend/src/chat.service.ts
@@ -23,8 +23,9 @@ export class ChatService {
       const questionEmbedding = await this.generateEmbedding(question);
 
       // 2. Find most similar content chunks
+      const embeddingStr = JSON.stringify(questionEmbedding);
       const similarDocs = await this.prisma.$queryRaw`
-        SELECT content, 1 - (embedding <=> ${questionEmbedding}::vector) as similarity
+        SELECT content, 1 - (embedding <=> ${embeddingStr}::vector) as similarity
         FROM "DocumentEmbedding"
         WHERE "fileId" = ${fileId}
         ORDER BY similarity DESC


### PR DESCRIPTION
## Summary
Fixed a bug in the chat service where embedding vectors were not being properly serialized before being passed to the raw SQL query, causing potential type casting issues with PostgreSQL.

## Key Changes
- Convert `questionEmbedding` object to JSON string before passing to the SQL query
- Update the parameterized query to use the serialized embedding string instead of the raw object

## Implementation Details
The embedding vector needs to be explicitly serialized to a JSON string before being used in the raw SQL query. This ensures proper type casting when PostgreSQL interprets the `::vector` cast operation. Previously, passing the object directly could cause type mismatch errors or unexpected behavior in the similarity calculation.
